### PR TITLE
Scala support demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 build
+/.idea/

--- a/scalaModule/build.gradle
+++ b/scalaModule/build.gradle
@@ -1,12 +1,11 @@
 
 plugins {
     id "org.jetbrains.gradle.plugin.idea-ext"
+    id "scala"
 }
-
-idea {
-    module {
-        settings {
-            rootModuleType = "SCALA_MODULE"
-        }
-    }
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation 'org.scala-lang:scala3-library_3:3.1.1'
 }

--- a/scalaModule/src/main/scala/Hello.scala
+++ b/scalaModule/src/main/scala/Hello.scala
@@ -1,0 +1,5 @@
+object Hello {
+  def main(args: Array[String]) = {
+    println("Hello, world")
+  }
+}


### PR DESCRIPTION
Demo changes showing that IDEA-Ext is not required for Scala support in the Gradle project.